### PR TITLE
修复初始值越界和pickerView复用的Bug

### DIFF
--- a/pickerview/src/main/java/com/bigkoo/pickerview/lib/WheelView.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/lib/WheelView.java
@@ -349,6 +349,15 @@ public class WheelView extends View {
         if (adapter == null) {
             return;
         }
+        //initPosition越界会造成preCurrentIndex的值不正确
+        if(initPosition<0)
+        {
+            initPosition = 0;
+        }
+        if(initPosition>=adapter.getItemsCount())
+        {
+            initPosition = adapter.getItemsCount()-1;
+        }
         //可见的item数组
         Object visibles[] = new Object[itemsVisible];
         //滚动的Y值高度除去每行Item的高度，得到滚动了多少个item，即change数

--- a/pickerview/src/main/java/com/bigkoo/pickerview/view/WheelOptions.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/view/WheelOptions.java
@@ -79,10 +79,16 @@ public class WheelOptions<T> {
         wv_option2.setIsOptions(true);
         wv_option3.setIsOptions(true);
 
-        if (this.mOptions2Items == null)
+        if (this.mOptions2Items == null) {
             wv_option2.setVisibility(View.GONE);
-        if (this.mOptions3Items == null)
+        } else {
+            wv_option2.setVisibility(View.VISIBLE);
+        }
+        if (this.mOptions3Items == null) {
             wv_option3.setVisibility(View.GONE);
+        } else {
+            wv_option3.setVisibility(View.VISIBLE);
+        }
 
         // 联动监听器
         wheelListener_option1 = new OnItemSelectedListener() {
@@ -158,12 +164,17 @@ public class WheelOptions<T> {
         wv_option2.setIsOptions(true);
         wv_option3.setIsOptions(true);
 
-        if (this.N_mOptions2Items == null)
+        if (this.N_mOptions2Items == null) {
             wv_option2.setVisibility(View.GONE);
-        if (this.N_mOptions3Items == null)
+        } else {
+            wv_option2.setVisibility(View.VISIBLE);
+        }
+        if (this.N_mOptions3Items == null) {
             wv_option3.setVisibility(View.GONE);
+        } else {
+            wv_option3.setVisibility(View.VISIBLE);
+        }
     }
-
 
 
     public void setTextContentSize(int textSize) {


### PR DESCRIPTION
1. 修复OptionsPikerView 在复用时，第二列和第三列可能无法显示的Bug
2. 修复设定初始值越界而造成卡轮子滑动异常的Bug