### PR TITLE
修正在二级连动时一级选项的第一笔下面的二级数据为空时，会使得第一笔之后的二级栏位显示空白

### DIFF
--- a/app/src/main/java/com/bigkoo/pickerviewdemo/MainActivity.java
+++ b/app/src/main/java/com/bigkoo/pickerviewdemo/MainActivity.java
@@ -312,8 +312,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             @Override
             public void onOptionsSelect(int options1, int options2, int options3, View v) {
                 //返回的分别是三个级别的选中位置
-                String tx = options1Items.get(options1).getPickerViewText()
-                        + options2Items.get(options1).get(options2)
+                String opt1tx = options1Items.size() > 0 ? options1Items.get(options1).getPickerViewText() : "";
+                String opt2tx = options2Items.size() > 0 && options2Items.get(options1).size() > 0 ? options2Items.get(options1).get(options2) : "";
+                String tx = opt1tx + opt2tx
                        /* + options3Items.get(options1).get(options2).get(options3).getPickerViewText()*/;
                 btn_Options.setText(tx);
             }

--- a/wheelview/src/main/java/com/contrarywind/view/WheelView.java
+++ b/wheelview/src/main/java/com/contrarywind/view/WheelView.java
@@ -244,7 +244,7 @@ public class WheelView extends View {
      */
     private void measureTextWidthHeight() {
         Rect rect = new Rect();
-        for (int i = 0; i < adapter.getItemsCount(); i++) {
+        for (int i = 0; i <= adapter.getItemsCount(); i++) {
             String s1 = getContentText(adapter.getItem(i));
             paintCenterText.getTextBounds(s1, 0, s1.length(), rect);
 


### PR DESCRIPTION
当条件选择器中选项2的options2Items_01为空阵列时，会使得二级栏位显示空白