### PR TITLE
修复 省市区联动弹框与虚拟导航栏重叠的问题

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,8 @@
 
 buildscript {
     repositories {
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -20,10 +17,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        google()
     }
 }
 

--- a/pickerview/src/main/java/com/bigkoo/pickerview/view/BasePickerView.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/view/BasePickerView.java
@@ -81,7 +81,7 @@ public class BasePickerView {
             //如果只是要显示在屏幕的下方
             //decorView是activity的根View,包含 contentView 和 titleView
             if (mPickerOptions.decorView == null) {
-                mPickerOptions.decorView = (ViewGroup) ((Activity) context).getWindow().getDecorView();
+                mPickerOptions.decorView = (ViewGroup) ((Activity) context).getWindow().getDecorView().findViewById(android.R.id.content);
             }
             //将控件添加到decorView中
             rootView = (ViewGroup) layoutInflater.inflate(R.layout.layout_basepickerview, mPickerOptions.decorView, false);


### PR DESCRIPTION
旧版的弹框是没有这个问题的，我也不是很确定是否是故意改成这样的。

如果是故意为之，希望在 #690 里回复一下，不然，在选择地区过程中可能会误触发虚拟导航栏，导致不太好的用户体验。