### PR TITLE
修复 Gradle 5.x 版本不兼容的问题

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "com.bigkoo.pickerviewdemo"
@@ -24,8 +23,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':pickerview')
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.google.code.gson:gson:2.7'
+//    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':pickerview')
+//    implementation 'com.contrarywind:Android-PickerView:4.1.7'
+//    implementation 'com.contrarywind:wheelview:4.0.9'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.google.code.gson:gson:2.7'
 }

--- a/app/src/main/java/com/bigkoo/pickerviewdemo/TestImport.java
+++ b/app/src/main/java/com/bigkoo/pickerviewdemo/TestImport.java
@@ -1,0 +1,8 @@
+package com.bigkoo.pickerviewdemo;
+
+import com.contrarywind.interfaces.IPickerViewData;
+
+public class TestImport {
+
+    IPickerViewData data;
+}

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.4.0'
         classpath 'com.novoda:bintray-release:0.5.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/pickerview/build.gradle
+++ b/pickerview/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'com.novoda.bintray-release'//添加JCenter插件
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.2"
 
     defaultConfig {
         minSdkVersion 14
@@ -44,7 +43,7 @@ publish {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile project(path: ':wheelview')
-    compile 'com.android.support:support-annotations:28.0.0'
+//    compile fileTree(include: ['*.jar'], dir: 'libs')
+    api project(path: ':wheelview')
+    implementation 'com.android.support:support-annotations:28.0.0'
 }

--- a/wheelview/build.gradle
+++ b/wheelview/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'com.novoda.bintray-release'//添加插件
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.2"
 
     defaultConfig {
         minSdkVersion 14
@@ -44,6 +43,6 @@ publish {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:support-annotations:28.0.0'
+//    compile fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.android.support:support-annotations:28.0.0'
 }


### PR DESCRIPTION
#### 问题描述
当前版本使用 Gradle 5.x 会发生 `找不到 IPickerViewData` 的问题(#735 )。
通过测试发现，手动添加以下依赖项可以解决：
```Groovy
implementation 'com.contrarywind:wheelview:4.0.9'
```
因此可以判断是由于 `pickerview` 库中使用了 `compile` 方式依赖 ，这种方式在 5.x 以上不再导出依赖项，修改为 `api` 即可解决。

#### 主要修改
* 使用 `api` 方式依赖 `wheelview`
* 使用 `implementation` 方式依赖 `support-annotation`
* 删除未产生效果的 `compile fileTree(dir: 'libs', include: ['*.jar'])` 项
* 删除 `buildToolsVersion ` (因为新版本的 `android-gradle-plugin` 已弃用该配置)
* 在 `app` 模块加入了一个测试类 `TestImport`