### PR TITLE
新增选中项的背景色及分割线的宽度

### DIFF
--- a/app/src/main/java/com/bigkoo/pickerviewdemo/MainActivity.java
+++ b/app/src/main/java/com/bigkoo/pickerviewdemo/MainActivity.java
@@ -4,6 +4,7 @@ import android.app.Dialog;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Gravity;
@@ -206,6 +207,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 })
                 .setType(new boolean[]{true, true, true, true, true, true})
                 .isDialog(true) //默认设置false ，内部实现将DecorView 作为它的父控件。
+                .setDividerWidth(5)//设置选中条目分割线的线宽，单位px，若不设置默认为1
+                .setDividerColor(Color.RED)
+                .setSelectItemBgColor(Color.GREEN)//设置选中条目的背景色，若不设置默认为0xFFe7e7e7
                 .build();
 
         Dialog mDialog = pvTime.getDialog();

--- a/pickerview/src/main/java/com/bigkoo/pickerview/builder/TimePickerBuilder.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/builder/TimePickerBuilder.java
@@ -169,6 +169,26 @@ public class TimePickerBuilder {
     }
 
     /**
+     * 设置分割线的宽度
+     *
+     * @param dividerWidth
+     */
+    public TimePickerBuilder setDividerWidth(int dividerWidth) {
+        mPickerOptions.dividerWidth = dividerWidth;
+        return this;
+    }
+
+    /**
+     * 设置选中条目的颜色
+     *
+     * @param selectItemBgColor
+     */
+    public TimePickerBuilder setSelectItemBgColor(int selectItemBgColor) {
+        mPickerOptions.selectItemBgColor = selectItemBgColor;
+        return this;
+    }
+
+    /**
      * 设置分割线的类型
      *
      * @param dividerType

--- a/pickerview/src/main/java/com/bigkoo/pickerview/configure/PickerOptions.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/configure/PickerOptions.java
@@ -101,6 +101,8 @@ public class PickerOptions {
     public int textColorOut = 0xFFa8a8a8; //分割线以外的文字颜色
     public int textColorCenter = 0xFF2a2a2a; //分割线之间的文字颜色
     public int dividerColor = 0xFFd5d5d5; //分割线的颜色
+    public int dividerWidth = 1; //分割线的宽度
+    public int selectItemBgColor = 0xFFe7e7e7; //选中条目的背景色
     public int backgroundId = -1; //显示时的外部背景色颜色,默认是灰色
 
     public float lineSpacingMultiplier = 1.6f; // 条目间距倍数 默认1.6

--- a/pickerview/src/main/java/com/bigkoo/pickerview/view/TimePickerView.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/view/TimePickerView.java
@@ -138,6 +138,8 @@ public class TimePickerView extends BasePickerView implements View.OnClickListen
         wheelTime.setCyclic(mPickerOptions.cyclic);
         wheelTime.setDividerColor(mPickerOptions.dividerColor);
         wheelTime.setDividerType(mPickerOptions.dividerType);
+        wheelTime.setDividerWidth(mPickerOptions.dividerWidth);
+        wheelTime.setSelectItemBgColor(mPickerOptions.selectItemBgColor);
         wheelTime.setLineSpacingMultiplier(mPickerOptions.lineSpacingMultiplier);
         wheelTime.setTextColorOut(mPickerOptions.textColorOut);
         wheelTime.setTextColorCenter(mPickerOptions.textColorCenter);

--- a/pickerview/src/main/java/com/bigkoo/pickerview/view/WheelTime.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/view/WheelTime.java
@@ -47,10 +47,12 @@ public class WheelTime {
 
     private int textSize;
 
-    //文字的颜色和分割线的颜色
+    //文字的颜色和分割线的颜色、宽度、选中条目背景色
     private int textColorOut;
     private int textColorCenter;
     private int dividerColor;
+    private int dividerWidth;
+    private int selectItemBgColor;
 
     private float lineSpacingMultiplier;
     private WheelView.DividerType dividerType;
@@ -628,6 +630,24 @@ public class WheelTime {
         wv_seconds.setDividerColor(dividerColor);
     }
 
+    private void setDividerWidth() {
+        wv_day.setDividerWidth(dividerWidth);
+        wv_month.setDividerWidth(dividerWidth);
+        wv_year.setDividerWidth(dividerWidth);
+        wv_hours.setDividerWidth(dividerWidth);
+        wv_minutes.setDividerWidth(dividerWidth);
+        wv_seconds.setDividerWidth(dividerWidth);
+    }
+
+    private void setSelectItemBgColor() {
+        wv_day.setSelectItemBgColor(selectItemBgColor);
+        wv_month.setSelectItemBgColor(selectItemBgColor);
+        wv_year.setSelectItemBgColor(selectItemBgColor);
+        wv_hours.setSelectItemBgColor(selectItemBgColor);
+        wv_minutes.setSelectItemBgColor(selectItemBgColor);
+        wv_seconds.setSelectItemBgColor(selectItemBgColor);
+    }
+
     private void setDividerType() {
 
         wv_day.setDividerType(dividerType);
@@ -882,6 +902,26 @@ public class WheelTime {
     public void setDividerColor(int dividerColor) {
         this.dividerColor = dividerColor;
         setDividerColor();
+    }
+
+    /**
+     * 设置分割线的宽度
+     *
+     * @param dividerWidth
+     */
+    public void setDividerWidth(int dividerWidth) {
+        this.dividerWidth = dividerWidth;
+        setDividerWidth();
+    }
+
+    /**
+     * 设置选中条目的背景色
+     *
+     * @param selectItemBgColor
+     */
+    public void setSelectItemBgColor(int selectItemBgColor) {
+        this.selectItemBgColor = selectItemBgColor;
+        setSelectItemBgColor();
     }
 
     /**

--- a/wheelview/src/main/java/com/contrarywind/view/WheelView.java
+++ b/wheelview/src/main/java/com/contrarywind/view/WheelView.java
@@ -61,6 +61,7 @@ public class WheelView extends View {
     private Paint paintOuterText;
     private Paint paintCenterText;
     private Paint paintIndicator;
+    private Paint paintSelectItem;
 
     private WheelAdapter adapter;
 
@@ -76,6 +77,8 @@ public class WheelView extends View {
     private int textColorOut;
     private int textColorCenter;
     private int dividerColor;
+    private int dividerWidth;
+    private int selectItemBgColor;
 
     // 条目间距倍数
     private float lineSpacingMultiplier = 1.6F;
@@ -133,7 +136,7 @@ public class WheelView extends View {
         super(context, attrs);
 
         textSize = getResources().getDimensionPixelSize(R.dimen.pickerview_textsize);//默认大小
-
+        dividerWidth = 1;//默认线宽
         DisplayMetrics dm = getResources().getDisplayMetrics();
         float density = dm.density; // 屏幕密度比（0.75/1.0/1.5/2.0/3.0）
 
@@ -155,6 +158,9 @@ public class WheelView extends View {
             textColorOut = a.getColor(R.styleable.pickerview_wheelview_textColorOut, 0xFFa8a8a8);
             textColorCenter = a.getColor(R.styleable.pickerview_wheelview_textColorCenter, 0xFF2a2a2a);
             dividerColor = a.getColor(R.styleable.pickerview_wheelview_dividerColor, 0xFFd5d5d5);
+            dividerWidth = a.getInt(R.styleable.pickerview_wheelview_dividerWidth, dividerWidth);
+            selectItemBgColor = a.getColor(R.styleable.pickerview_wheelview_selectItemBgColor,
+                    0xFFe7e7e7);
             textSize = a.getDimensionPixelOffset(R.styleable.pickerview_wheelview_textSize, textSize);
             lineSpacingMultiplier = a.getFloat(R.styleable.pickerview_wheelview_lineSpacingMultiplier, lineSpacingMultiplier);
             a.recycle();//回收内存
@@ -204,6 +210,11 @@ public class WheelView extends View {
         paintIndicator = new Paint();
         paintIndicator.setColor(dividerColor);
         paintIndicator.setAntiAlias(true);
+        paintIndicator.setStrokeWidth(dividerWidth);
+
+        paintSelectItem = new Paint();
+        paintSelectItem.setColor(selectItemBgColor);
+        paintSelectItem.setAntiAlias(true);
 
         setLayerType(LAYER_TYPE_SOFTWARE, null);
     }
@@ -435,7 +446,7 @@ public class WheelView extends View {
             canvas.drawLine(0.0F, firstLineY, measuredWidth, firstLineY, paintIndicator);
             canvas.drawLine(0.0F, secondLineY, measuredWidth, secondLineY, paintIndicator);
         }
-
+        canvas.drawRect(0.0f, firstLineY, measuredWidth, secondLineY, paintSelectItem);
         //只显示选中项Label文字的模式，并且Label文字不为空，则进行绘制
         if (!TextUtils.isEmpty(label) && isCenterLabel) {
             //绘制文字，靠右并留出空隙
@@ -758,6 +769,16 @@ public class WheelView extends View {
     public void setDividerColor(int dividerColor) {
         this.dividerColor = dividerColor;
         paintIndicator.setColor(dividerColor);
+    }
+
+    public void setDividerWidth(int dividerWidth) {
+        this.dividerWidth = dividerWidth;
+        paintIndicator.setStrokeWidth(dividerWidth);
+    }
+
+    public void setSelectItemBgColor(int selectItemBgColor) {
+        this.selectItemBgColor = selectItemBgColor;
+        paintSelectItem.setColor(selectItemBgColor);
     }
 
     public void setDividerType(DividerType dividerType) {

--- a/wheelview/src/main/res/values/attrs.xml
+++ b/wheelview/src/main/res/values/attrs.xml
@@ -10,6 +10,8 @@
         <attr name="wheelview_textColorOut" format="color"/>
         <attr name="wheelview_textColorCenter" format="color"/>
         <attr name="wheelview_dividerColor" format="color"/>
+        <attr name="wheelview_dividerWidth" format="integer"/>
+        <attr name="wheelview_selectItemBgColor" format="color"/>
         <attr name="wheelview_lineSpacingMultiplier" format="float"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
使用方法如下，在mainActivity的initTimePicker()方法中
.setDividerWidth(5)//设置选中条目分割线的线宽，单位px，若不设置默认为1                   .setSelectItemBgColor(Color.GREEN)//设置选中条目的背景色，若不设置默认为0xFFe7e7e7