### PR TITLE
修复 WheelView 的一个NPE

### DIFF
--- a/wheelview/src/main/java/com/contrarywind/view/WheelView.java
+++ b/wheelview/src/main/java/com/contrarywind/view/WheelView.java
@@ -669,6 +669,10 @@ public class WheelView extends View {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
+        //防止还没设置 adapter，先触发了触摸事件导致的 NPE
+        if (adapter == null) {
+           return super.onTouchEvent(event);
+        }
         boolean eventConsumed = gestureDetector.onTouchEvent(event);
         boolean isIgnore = false;//超过边界滑动时，不再绘制UI。
 


### PR DESCRIPTION
问题：当 WheelView 没设置 Adapter ，但手指触摸了 WheelView ，由于 onTouchEvent 没用对 adapter 进行判空处理，导致调用 adapter 报 NPE