### PR TITLE
[fix] 修复在数据非常少的时候的滑动卡顿

### DIFF
--- a/wheelview/src/main/java/com/contrarywind/view/WheelView.java
+++ b/wheelview/src/main/java/com/contrarywind/view/WheelView.java
@@ -670,11 +670,8 @@ public class WheelView extends View {
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         boolean eventConsumed = gestureDetector.onTouchEvent(event);
-        boolean isIgnore = false;//超过边界滑动时，不再绘制UI。
-
         float top = -initPosition * itemHeight;
         float bottom = (adapter.getItemsCount() - 1 - initPosition) * itemHeight;
-        float ratio = 0.25f;
 
         switch (event.getAction()) {
             case MotionEvent.ACTION_DOWN:
@@ -690,13 +687,10 @@ public class WheelView extends View {
 
                 // normal mode。
                 if (!isLoop) {
-                    if ((totalScrollY - itemHeight * ratio < top && dy < 0)
-                            || (totalScrollY + itemHeight * ratio > bottom && dy > 0)) {
-                        //快滑动到边界了，设置已滑动到边界的标志
-                        totalScrollY -= dy;
-                        isIgnore = true;
-                    } else {
-                        isIgnore = false;
+                    if (totalScrollY < top) {
+                        totalScrollY = (int) top;
+                    } else if (totalScrollY > bottom) {
+                        totalScrollY = (int) bottom;
                     }
                 }
                 break;
@@ -735,7 +729,7 @@ public class WheelView extends View {
                 }
                 break;
         }
-        if (!isIgnore && event.getAction() != MotionEvent.ACTION_DOWN) {
+        if (event.getAction() != MotionEvent.ACTION_DOWN) {
             invalidate();
         }
         return true;


### PR DESCRIPTION
作者之前给滑动到边界时做了减速的效果，但是在数据只有两三条的时候，这个减速效果就变成了卡顿。参考[androidWheelView](https://github.com/weidongjian/androidWheelView/blob/master/loopview/src/main/java/com/weigan/loopview/LoopView.java)的实现，修改了实现方案，在数据只有两三条的时候，不会出现卡顿。