### PR TITLE
fix the bug that PickView disappears

### DIFF
--- a/pickerview/src/main/java/com/bigkoo/pickerview/builder/OptionsPickerBuilder.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/builder/OptionsPickerBuilder.java
@@ -3,6 +3,7 @@ package com.bigkoo.pickerview.builder;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.support.annotation.ColorInt;
+import android.support.annotation.LayoutRes;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -102,7 +103,19 @@ public class OptionsPickerBuilder {
         return this;
     }
 
-    public OptionsPickerBuilder setLayoutRes(int res, CustomListener listener) {
+    /**
+     * 设置选择器自定义布局
+     * 注意：CustomListener不能为null, 否则该方法调用无效，即无法加载传入的自定义布局，详情查看
+     * {@link OptionsPickerView#initView(Context)}
+     *
+     * @param res 自定义布局
+     * @param listener 布局加载监听
+     * @return OptionsPickerBuilder
+     */
+    public OptionsPickerBuilder setLayoutRes(@LayoutRes int res, CustomListener listener) {
+        if (listener == null){
+            throw new IllegalArgumentException("CustomListener is null");
+        }
         mPickerOptions.layoutRes = res;
         mPickerOptions.customListener = listener;
         return this;

--- a/pickerview/src/main/java/com/bigkoo/pickerview/builder/TimePickerBuilder.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/builder/TimePickerBuilder.java
@@ -2,6 +2,7 @@ package com.bigkoo.pickerview.builder;
 
 import android.content.Context;
 import android.support.annotation.ColorInt;
+import android.support.annotation.LayoutRes;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -155,7 +156,19 @@ public class TimePickerBuilder {
         return this;
     }
 
-    public TimePickerBuilder setLayoutRes(int res, CustomListener customListener) {
+    /**
+     * 设置时间选择器自定义布局
+     * 注意：CustomListener不能为null, 否则该方法调用无效，即无法加载传入的自定义布局，详情查看
+     * {@link TimePickerView#initView(Context)}
+     *
+     * @param res 自定义布局
+     * @param customListener 布局加载监听
+     * @return TimePickerBuilder
+     */
+    public TimePickerBuilder setLayoutRes(@LayoutRes int res, CustomListener customListener) {
+        if (customListener == null){
+            throw new IllegalArgumentException("CustomListener is null");
+        }
         mPickerOptions.layoutRes = res;
         mPickerOptions.customListener = customListener;
         return this;

--- a/pickerview/src/main/java/com/bigkoo/pickerview/view/BasePickerView.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/view/BasePickerView.java
@@ -70,13 +70,6 @@ public class BasePickerView {
             contentContainer.setLayoutParams(params);
             //创建对话框
             createDialog();
-            //给背景设置点击事件,这样当点击内容以外的地方会关闭界面
-            dialogView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    dismiss();
-                }
-            });
         } else {
             //如果只是要显示在屏幕的下方
             //decorView是activity的根View,包含 contentView 和 titleView
@@ -277,6 +270,17 @@ public class BasePickerView {
             } else {
                 view.setOnTouchListener(null);
             }
+
+            View pickViewContainer = rootView.findViewById(R.id.content_container);
+            pickViewContainer.setOnTouchListener(new View.OnTouchListener() {
+                @Override
+                public boolean onTouch(View v, MotionEvent event) {
+                    //do nothing, just consume touch events to avoid that PickView
+                    //disappears while clicking this PickView own area under the
+                    //condition that setOutSideCancelable() is true
+                    return true;
+                }
+            });
         }
 
         return this;

--- a/pickerview/src/main/java/com/bigkoo/pickerview/view/OptionsPickerView.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/view/OptionsPickerView.java
@@ -33,7 +33,6 @@ public class OptionsPickerView<T> extends BasePickerView implements View.OnClick
     }
 
     private void initView(Context context) {
-        setDialogOutSideCancelable();
         initViews();
         initAnim();
         initEvents();

--- a/pickerview/src/main/java/com/bigkoo/pickerview/view/TimePickerView.java
+++ b/pickerview/src/main/java/com/bigkoo/pickerview/view/TimePickerView.java
@@ -35,7 +35,6 @@ public class TimePickerView extends BasePickerView implements View.OnClickListen
     }
 
     private void initView(Context context) {
-        setDialogOutSideCancelable();
         initViews();
         initAnim();
 


### PR DESCRIPTION
**Desc:** 
If we use custom layout , and  in this PickView we click it's child views or areas which don't consume touch events，the following will occur.

- If PickView shows as a dialog, PickView will disappear directly,  even if _setOutSideCancelable()_ is true or false
- If not show as a dialog and _setOutSideCancelable()_ is true, PickView still disappears 

You can easily reproduce the situation in your sample app just by adding the follwing code to MainActivity#initCustomTimePicker(),  run app and once you click the top middle area of the PickView (this area doesn't consume any touch events), you will find this PickView disappeared 
     ` .isDialog(true)
                .setOutSideCancelable(false)
                .build();`

